### PR TITLE
Support for multiple accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,8 +129,9 @@ async function processSamlResponse(response, credentialsPath, profile, role) {
 
   logger.debug('Parsed SAML assertion %O', saml.parsedSaml);
 
-  const attribute = saml.getAttribute('https://aws.amazon.com/SAML/Attributes/Role')[0];
-  const roleArn = role || attribute.match(REGEX_PATTERN_ROLE)[0];
+  const isTargetRole = (element) => element.match(role || REGEX_PATTERN_ROLE)
+  const attribute = saml.getAttribute('https://aws.amazon.com/SAML/Attributes/Role').find(isTargetRole);
+  const roleArn = attribute.match(REGEX_PATTERN_ROLE)[0];
   const principalArn = attribute.match(REGEX_PATTERN_PRINCIPAL)[0];
 
   let sessionDuration = DEFAULT_SESSION_DURATION;


### PR DESCRIPTION
For users that have multiple entries in the https://aws.amazon.com/SAML/Attributes/Role element of the saml assertion, login will fail if --aws-role-arn is specified to a value that is not the first element  in the attribute, because the principalArn is always taken from the first element.  This result in a "ValidationError: Principal exists outside the account of the Role being assumed.." error if the principalArn does not happen to be the same across the multiple entries.

This PR changes that logic to use the principalArn from the same entry where the role is found.
