### PR TITLE
Fix ERR_INVALID_ARG_TYPE error on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const EXPIRATION_DELTA = 30e3; // 30 seconds
 const PROJECT_NAMESPACE = 'io.github.ruimarinho.gsts';
 
 // LaunchAgents plist path.
-const MACOS_LAUNCH_AGENT_HELPER_PATH = path.join(process.env.HOME, 'Library', 'LaunchAgents', `${PROJECT_NAMESPACE}.plist`)
+const MACOS_LAUNCH_AGENT_HELPER_PATH = path.join(process.env.HOME || '', 'Library', 'LaunchAgents', `${PROJECT_NAMESPACE}.plist`)
 
 // Parse command line arguments.
 const argv = require('yargs')


### PR DESCRIPTION
Currently if the user doesn't have the HOME env var set they get the following error when running gsts
```
internal/validators.js:117
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:117:11)
    at Object.join (path.js:375:7)
    at Object.<anonymous> (C:\Users\--\AppData\Roaming\npm\node_modules\gsts\index.js:42:45)
    at Module._compile (internal/modules/cjs/loader.js:1158:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
    at Module.load (internal/modules/cjs/loader.js:1002:32)
    at Function.Module._load (internal/modules/cjs/loader.js:901:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47 {
  code: 'ERR_INVALID_ARG_TYPE'
```

Made a small change to make it so the plist file path generation doesn't crash on windows.
