### PR TITLE
Spawn headful process using Node environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,7 +407,7 @@ async function openConsole(url) {
   if (!isAuthenticated && !argv.headful) {
     logger.info('User is not authenticated, spawning headful instance');
 
-    const args = ['--headful'];
+    const args = [__filename, '--headful'];
 
     for (const arg of ['awsProfile', 'awsRoleArn', 'awsSharedCredentialsFile', 'clean', 'force', 'idpId', 'spId', 'username', 'verbose']) {
       if (!argv[arg]) {
@@ -417,7 +417,7 @@ async function openConsole(url) {
       args.push(`--${arg}=${argv[arg]}`)
     }
 
-    const ui = childProcess.spawn('gsts', args, { stdio: 'inherit' });
+    const ui = childProcess.spawn(process.execPath, args, { stdio: 'inherit' });
 
     ui.on('close', code => logger.debug(`Headful instance has exited with code ${code}`))
   }


### PR DESCRIPTION
Closes #5

Info
-----
* Currently, spawning a headful process to Authenticate relies on the assumption that `gsts` is on the PATH, so it fails if that assumption is violated.
* Node provides us with the information we need to spawn the process directly, in `process.execPath` and `__filename`

Changes
-----
* Updated the spawning of a headful instance to spawn `process.execPath` (the path to the currently running Node) instead of `gsts` directly.
* Added `__filename` (the path to the currently running script) to the beginning of the arguments.
* The net result is that instead of calling `gsts <args>`, we call `/path/to/node /path/to/index.js <args>` directly.

Tested
-----
* Confirmed that in an environment without `gsts` on the PATH, the headful instance is still spawned correctly.