### PR TITLE
Allow overriding session duration

### DIFF
--- a/credentials-manager.js
+++ b/credentials-manager.js
@@ -16,9 +16,10 @@ const ini = require('ini');
  */
 
 class CredentialsManager {
-  constructor(logger, { sessionDefaultDuration, sessionExpirationDelta } = {}) {
+  constructor(logger, { sessionDefaultDuration, sessionDurationOverride, sessionExpirationDelta } = {}) {
     this.logger = logger;
     this.sessionDefaultDuration = sessionDefaultDuration;
+    this.sessionDurationOverride = sessionDurationOverride;
     this.sessionExpirationDelta = sessionExpirationDelta;
     this.parser = new Parser(logger);
   }
@@ -32,7 +33,7 @@ class CredentialsManager {
       return {
         roles,
         samlAssertion,
-        sessionDuration: sessionDuration || this.sessionDefaultDuration
+        sessionDuration: this.sessionDurationOverride || sessionDuration || this.sessionDefaultDuration
       }
     }
 
@@ -47,7 +48,7 @@ class CredentialsManager {
     return {
       roles: [customRole],
       samlAssertion,
-      sessionDuration: sessionDuration || this.sessionDefaultDuration
+      sessionDuration: this.sessionDurationOverride || sessionDuration || this.sessionDefaultDuration
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ const argv = require('yargs')
     'aws-role-arn': {
       description: 'AWS role ARN to authenticate with'
     },
+    'aws-session-duration': {
+      description: `AWS session duration in seconds (defaults to the value provided by Google, and if that is not provided then ${SESSION_DEFAULT_DURATION})`,
+      type: 'number'
+    },
     'aws-shared-credentials-file': {
       description: 'AWS shared credentials file',
       default: path.join(homedir, '.aws', 'credentials')
@@ -121,6 +125,7 @@ const daemonizer = new Daemonizer(logger);
 
 const credentialsManager = new CredentialsManager(logger, {
   sessionDefaultDuration: SESSION_DEFAULT_DURATION,
+  sessionDurationOverride: argv.awsSessionDuration,
   sessionExpirationDelta: SESSION_EXPIRATION_DELTA
 });
 


### PR DESCRIPTION
* Adds --aws-session-duration argument
* When set to > 0, will be used instead of the value found in the parsed
  SAML (and where that is not set, the default value)

Should solve #13

## TODO

- [ ] Tests
- [ ] Daemonizer