### PR TITLE
Add support for credential_process

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Additionally, this extensions uses [chrome.runtime](https://github.com/google/u2
 
 In conclusion, the only alternative to successfully enable legacy U2F support on puppeteer is to skip this evasion technique and enable component extensions. For the time being and due to the potential increase in detection, U2F support remains behind a feature flag.
 
+### `credential_process`
+
+`gsts` can be invoked as a credential source through [`credential_process`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) with the `--json` option.
+
+For example, add this to your `~/.aws/config` file:
+
+```
+[profile example]
+credential_process = gsts --aws-profile=gsts-example --aws-role-arn arn:aws:iam::111111111111:role/SSOAccessRole --idp-id aaaaaaaaa --sp-id 111111111111 --json
+```
+
 ## Amazon ECR
 
 If you'd like to automatically authenticate your Docker installation before pulling private images from Amazon ECR, you can use the fantastic [ECR Docker Credential Helper](https://github.com/awslabs/amazon-ecr-credential-helper) in combination with `gsts`.

--- a/credentials-manager.js
+++ b/credentials-manager.js
@@ -160,6 +160,26 @@ class CredentialsManager {
   }
 
   /**
+   * Print JSON output for use with credential_process
+   * See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+   */
+
+  async printJSONOutput(path, profile) {
+    this.logger.debug('Outputting data as JSON');
+
+    const credentials = await this.loadCredentials(path, profile);
+
+    let credentialsAsJson = {
+      Version: 1,
+      AccessKeyId: credentials.aws_access_key_id,
+      SecretAccessKey: credentials.aws_secret_access_key,
+      SessionToken: credentials.aws_session_token,
+      Expiration: credentials.aws_session_expiration
+    }
+    console.log(JSON.stringify(credentialsAsJson))
+  }
+
+  /**
    * Extract session expiration from AWS credentials file for a given profile.
    * The property `sessionExpirationDelta` represents a safety buffer to avoid requests
    * failing at the exact time of expiration.

--- a/index.js
+++ b/index.js
@@ -60,6 +60,10 @@ const cliOptions = {
     boolean: false,
     description: `Enable experimental U2F support`
   },
+  'json': {
+    boolean: false,
+    description: 'JSON output (compatible with AWS config\'s credential_process)'
+  },
   'force': {
     boolean: false,
     description: 'Force re-authorization even with valid session'
@@ -185,6 +189,10 @@ const credentialsManager = new CredentialsManager(logger);
         logger.info('Login is still valid, no need to re-authorize!');
       }
 
+      if (argv.json) {
+        await credentialsManager.printJSONOutput(argv.awsSharedCredentialsFile, argv.awsProfile);
+      }
+
       return;
     }
   }
@@ -269,6 +277,9 @@ const credentialsManager = new CredentialsManager(logger);
           logger.debug(`Login successful${ argv.verbose ? ` and credentials stored in "${argv.awsSharedCredentialsFile}" under AWS profile "${argv.awsProfile}" with role ARN "${role.roleArn}"` : '!' }`);
         } else {
           logger.succeed('Login successful!');
+        }
+        if (argv.json) {
+          await credentialsManager.printJSONOutput(argv.awsSharedCredentialsFile, argv.awsProfile);
         }
       } catch (e) {
         logger.debug('An error has ocurred while authenticating', e);


### PR DESCRIPTION
Hello! 👋 

This PR's goal is to add support for AWS config `credential_process` option (see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html). This allows using `gsts` as a standard credential helper, and works cross-platform for re-obtaining STS tokens as needed. 👍 

I opted to add a new option, `--json`, that prints out credentials to stdout in the expected format.

Let me know if there's anything else I can do to help this forward, or if there's a better way to do this :)

Thank you!