### PR TITLE
Fix: `puppeteer-device-viewport-plugin` missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "logger.js",
     "parser.js",
     "puppeteer-iframe-plugin.js",
+    "puppeteer-device-viewport-plugin.js",
     "role.js"
   ],
   "keywords": [


### PR DESCRIPTION
I had troubles today with version 2.3.1. 

I got the following error when executing any `gsts` command, for example `gsts --version`:
```
$ gsts --version

internal/modules/cjs/loader.js:628
    throw err;
    ^

Error: Cannot find module './puppeteer-device-viewport-plugin'
Require stack:
- /Users/denis.silva/.config/yarn/global/node_modules/gsts/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:625:15)
    at Function.Module._load (internal/modules/cjs/loader.js:527:27)
    at Module.require (internal/modules/cjs/loader.js:683:19)
    at require (internal/modules/cjs/helpers.js:16:16)
    at Object.<anonymous> (/Users/denis.silva/.config/yarn/global/node_modules/gsts/index.js:9:30)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:643:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:839:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/denis.silva/.config/yarn/global/node_modules/gsts/index.js'
  ]
}
```

I notice the file `puppeteer-device-viewport-plugin.js` is not included in the `package.json`, and `index.js` imports it directly.

After I manually copied the file `puppeteer-device-viewport-plugin.js` to the gsts module (in my case, `/Users/denis.silva/.config/yarn/global/node_modules/gsts`) it worked fine.

Can you check it, please?

Cheers!