### PR TITLE
Add support for the Google Chrome Endpoint Verification extension

### DIFF
--- a/endpoint-verification.js
+++ b/endpoint-verification.js
@@ -1,0 +1,55 @@
+import { promises } from 'fs';
+import { compare, coerce } from 'semver';
+import { join } from 'path';
+
+export class EndpointVerification {
+  constructor(logger) {
+    this.logger = logger;
+  }
+
+  async huntForExtension() {
+    let extensionsDirectory = join(
+      process.env.HOME,
+      'Library/Application Support/Google/Chrome/Default/Extensions'
+    );
+    let extensionIdentifier = 'callobklhcbilhphinckomhgkigmfocg';
+    let endpointVerificationExtensionDirectory = join(
+      extensionsDirectory,
+      extensionIdentifier
+    );
+
+    try {
+      const files = await promises.readdir(
+        endpointVerificationExtensionDirectory
+      );
+
+      if (files && files.length > 0) {
+        let latestExtensionVersion = files.toSorted((x, y) => {
+          return compare(coerce(y), coerce(x));
+        })[0];
+
+        this.logger.debug('ENDPOINT VERIFICATION ENABLED');
+        this.logger.debug(
+          `Found Endpoint Verification Extension version installed: ${latestExtensionVersion}`
+        );
+
+        return join(
+          endpointVerificationExtensionDirectory,
+          latestExtensionVersion
+        );
+      } else {
+        return null;
+      }
+    } catch (error) {
+      this.logger.error('WARNING');
+      this.logger.error(
+        `Endpoint verification requested but plugin not found at ${endpointVerificationExtensionDirectory}`
+      );
+      this.logger.error(
+        'Please make sure you have installed the Google Endpoint Verification Chrome Extension at: https://chrome.google.com/webstore/detail/endpoint-verification/callobklhcbilhphinckomhgkigmfocg?hl=en'
+      );
+
+      return null;
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -313,7 +313,9 @@ const endpointVerification = new EndpointVerification(logger);
       if (argv.username) {
         logger.debug(`Pre-filling email with ${argv.username}`);
 
-        await page.fill('input[type=email]', argv.username)
+        try {
+          await page.fill('input[type=email]', argv.username, {timeout: 2000})
+        } catch { };
       }
 
       await page.waitForResponse('https://signin.aws.amazon.com/saml');

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "ora": "^6.1.2",
         "playwright": "^1.36.2",
         "prompts": "^2.4.2",
+        "semver": "^7.5.4",
         "trash": "^8.1.1",
         "yargs": "^17.7.1"
       },
@@ -847,6 +848,15 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.21.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
@@ -893,6 +903,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -3821,6 +3840,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
@@ -4325,39 +4353,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/jest-util": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
@@ -4612,6 +4607,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/makeerror": {
@@ -5278,13 +5282,34 @@
       ]
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "files": [
     "config-manager.js",
     "credentials-manager.js",
+    "endpoint-verification.js",
     "errors.js",
     "formatter.js",
     "index.js",
@@ -40,6 +41,7 @@
     "ora": "^6.1.2",
     "playwright": "^1.36.2",
     "prompts": "^2.4.2",
+    "semver": "^7.5.4",
     "trash": "^8.1.1",
     "yargs": "^17.7.1"
   },

--- a/parameters.js
+++ b/parameters.js
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 // Define all available cli options.
 export function generateCliParameters(paths) {
   return {
@@ -18,10 +20,11 @@ export function generateCliParameters(paths) {
       description: 'AWS region to send requests to',
       required: true,
       awsConfigKey: 'region',
+      default: 'us-east-1'
     },
     'cache-dir': {
       description: 'Where to store cached data',
-      default: paths.cache,
+      default: path.join(process.env.HOME, '.aws'),
       awsConfigKey: 'gsts.cache_dir'
     },
     'clean': {
@@ -34,6 +37,11 @@ export function generateCliParameters(paths) {
       type: 'boolean',
       default: true,
       hidden: true,
+    },
+    'endpoint-verification': {
+      type: 'boolean',
+      default: false,
+      description: `Enable endpoint verification`
     },
     'force': {
       type: 'boolean',
@@ -69,7 +77,8 @@ export function generateCliParameters(paths) {
     },
     'playwright-engine-executable-path': {
       description: 'Set playwright executable path for browser engine',
-      awsConfigKey: 'gsts.playwright_engine_executable_path'
+      awsConfigKey: 'gsts.playwright_engine_executable_path',
+      alias: 'engine-executable-path'
     },
     'playwright-engine-channel': {
       description: 'Set playwright browser engine channel',


### PR DESCRIPTION
This PR adds support for the [Endpoint Verification](https://chrome.google.com/webstore/detail/endpoint-verification/callobklhcbilhphinckomhgkigmfocg?hl=en) extension to support [Context Aware Access](https://support.google.com/a/answer/9275380?hl=en) to your [AWS SAML app](https://aws.amazon.com/blogs/desktop-and-application-streaming/setting-up-g-suite-saml-2-0-federation-with-amazon-appstream-2-0/), which is a feature of [Cloud Identity Premium](https://cloud.google.com/identity). 

This means, for example, that you can ensure that users of gsts are running on the latest version of MacOS, on a laptop whose serial number is registered to your company.

This PR works by detecting whether or not the Endpoint Verification Extension has already been installed on your system (presumably it would have been if this is a feature your organization is trying to use). If so, it tells Chromium about the local path, because the only way to get Chromium to use extensions if if they are already downloaded locally.
