### PR TITLE
Work correctly with multiple profiles

### DIFF
--- a/config-manager.js
+++ b/config-manager.js
@@ -24,24 +24,12 @@ export async function processConfig(cliParameters, argv, env, isTTY) {
   // If defined, `$AWS_REGION` overrides the values in the environment variable
   // `$AWS_DEFAULT_REGION` and the profile setting region. You can override `$AWS_REGION`
   // by using the `--aws-region` command line parameter.
-  if (!argv.awsRegion && env.AWS_REGION) {
-    argv.awsRegion = argv['aws-region'] = env.AWS_REGION;
-  }
-
-  // If defined, `$AWS_DEFAULT_REGION` overrides the value for the profile setting region.
-  // You can override `$AWS_DEFAULT_REGION` by using the `--aws-region` command line parameter.
-  if (!argv.awsRegion && env.AWS_DEFAULT_REGION) {
-    argv.awsRegion = argv['aws-region'] = env.AWS_DEFAULT_REGION;
-  }
+  argv.awsRegion = argv['aws-region'] = argv['aws-region'] || env.AWS_REGION || env.AWS_DEFAULT_REGION;
 
   // If defined, `$AWS_PROFILE` overrides the behavior of using the profile named [default] in
   // the `aws` cli configuration file. You can override this environment variable by using the
   // `--aws-profile` command line parameter.
-  if (!argv.awsProfile && env.AWS_PROFILE) {
-    argv.awsProfile = argv['aws-profile'] = env.AWS_PROFILE;
-  } else {
-    argv.awsProfile = argv['aws-profile'] = 'default'
-  }
+  argv.awsProfile = argv['aws-profile'] = argv['aws-profile'] || env.AWS_PROFILE || 'default';
 
   for (let parameterKey in cliParameters) {
     // Test if this specific command line parameter is supported via the `aws` cli profile configuration.

--- a/credentials-manager.js
+++ b/credentials-manager.js
@@ -123,7 +123,16 @@ export class CredentialsManager {
    */
 
   async saveCredentials(profile, session) {
-    const contents = ini.encode(session.toIni(profile));
+    const outputs = {};
+    try {
+      const credentials = ini.parse(await readFile(this.credentialsFile, 'utf-8'));
+      Object.keys(credentials).forEach(prof => {
+        outputs[prof] = ini.encode(Session.fromIni(credentials[prof]).toIni(prof));
+      })
+    } catch {}
+
+    outputs[profile] = ini.encode(session.toIni(profile));
+    const contents = Object.values(outputs).join("\n");
 
     await mkdir(dirname(this.credentialsFile), { recursive: true });
     await writeFile(this.credentialsFile, contents);

--- a/index.js
+++ b/index.js
@@ -117,10 +117,6 @@ const credentialsManager = new CredentialsManager(logger, argv.awsRegion, argv['
         logger.info('Session has expired on %s, refreshing credentials...', session.expiresAt);
       }
     } catch (e) {
-      // Credentials file not being found is an expected error.
-      if (e.code !== 'ENOENT') {
-        throw e;
-      }
     }
   }
 


### PR DESCRIPTION
* Fix config-manager.js to handle overrides and fall-backs, for aws_profile and aws_region
* Read the cache file, before writing it back

Behavior can be seen working in the wild by running `npm i @jontg/gsts`