### PR TITLE
added AccountChooser in ssoPage url test

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,7 +264,7 @@ const credentialsManager = new CredentialsManager(logger, argv.awsRegion, argv['
       throw new Error(`Got status code "${ssoPage.status()}" while requesting "${SAML_URL}"`);
     }
 
-    if (/ServiceLogin|InteractiveLogin/.test(ssoPage.url())) {
+    if (/ServiceLogin|InteractiveLogin|AccountChooser/.test(ssoPage.url())) {
       if (!isAuthenticated && !argv.headful) {
         logger.warn('User is not authenticated, spawning headful instance');
 


### PR DESCRIPTION
When the google session times out (or being signed out manually from the accounts settings), google give the "choose an account" page before signing in again:

![image](https://github.com/ruimarinho/gsts/assets/7107401/8277f71a-205e-424f-8ab9-bca7f0a1ed99)

This causes gsts to get stuck on "Logging in" phase, and it needs to be run with `--clean` argument in order to sign in again, which flaws the interactive way gsts works. I've fixed it by adding `AccountChooser` to the ssoPage url test, which then identifies this page, and spawns the browser for sign in again.

( The url of the "choose an account" page is something like that:
https://accounts.google.com/AccountChooser/signinchooser?continue=https%3A%2F%2Faccounts.google.com%2Fo%2Fsaml2%2Finitsso%3Fidpid%XXXXXX%26spid%XXXXXX%26forceauthn%3Dtrue%26from_login%3DXXXXXX&ltmpl=popup&btmpl=authsub&scc=1&oauth=1&flowName=GlifWebSignIn&flowEntry=AccountChooser )
