### PR TITLE
Add --list-available-roles to print the list of roles available to assume and exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ const credentialsManager = new CredentialsManager(logger, argv.awsRegion, argv['
     await trash(paths.data);
   }
 
-  if (!argv.headful) {
+  if (!argv.headful && !argv.listAvailableRoles) {
    logger.start('Logging in');
   }
 
@@ -145,6 +145,20 @@ const credentialsManager = new CredentialsManager(logger, argv.awsRegion, argv['
 
       try {
         let { availableRoles, roleToAssume, samlAssertion } = await credentialsManager.prepareRoleWithSAML(route.request().postDataJSON(), argv.awsRoleArn);
+
+        if (argv.listAvailableRoles) {
+          if (argv.output === 'json') {
+            process.stdout.write(JSON.stringify(availableRoles));
+          } else {
+            for (let role of availableRoles) {
+              process.stdout.write(role.roleArn+"\n");
+            }
+          }
+
+          logger.stop();
+          await context.close();
+          return;
+        }
 
         if (!roleToAssume && availableRoles.length > 1) {
           logger.stop();

--- a/parameters.js
+++ b/parameters.js
@@ -52,6 +52,11 @@ export function generateCliParameters(paths) {
       required: true,
       awsConfigKey: 'gsts.idp_id'
     },
+    'list-available-roles': {
+      description: 'List available roles and exit',
+      type: 'boolean',
+      default: false,
+    },
     'no-credentials-cache': {
       description: 'Disable default behaviour of storing credentials in --cache-dir',
       type: 'boolean'


### PR DESCRIPTION
Running `gsts ... --list-available-roles` prints the list of available roles and exits. Also, if `-o json` was given, the list of roles is then printed in JSON.

Please scrutinize my PR, I'm neither a TypeScript expert or know gsts internally well.

closes #56