### PR TITLE
fix console command

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ import { format as formatOutput } from './formatter.js';
 import { hideBin } from 'yargs/helpers';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
-import { openApp } from 'open';
+import openUrl from 'open';
 import envpaths from 'env-paths';
 import playwright from 'playwright';
 import prompts from 'prompts';
@@ -88,7 +88,7 @@ const credentialsManager = new CredentialsManager(logger, argv.awsRegion, argv['
   if (argv._[0] === 'console') {
     logger.debug('Opening url %s', SAML_URL);
 
-    return await openApp(SAML_URL);
+    return await openUrl(SAML_URL);
   }
 
   if (argv.clean) {


### PR DESCRIPTION
This [change](https://github.com/ruimarinho/gsts/commit/1a6730670e249b6883da07ec5f973b47ea2c154c) broke the console command (at least on linux), as openApp can not open urls. According to the [docs](https://www.npmjs.com/package/open) its also not meant to do that, but the default export is to be used instead.