### PR TITLE
config-manager: Fix normalization of the parameterKey parsed from aws config

### DIFF
--- a/config-manager.js
+++ b/config-manager.js
@@ -59,7 +59,7 @@ export async function processConfig(cliParameters, argv, env, isTTY) {
       }
 
       // Normalize into yargs structure.
-      argv[parameterKey] = argv[camalize(parameterKey)];
+      argv[camalize(parameterKey)] = argv[parameterKey];
     }
   }
 


### PR DESCRIPTION
I was debugging why I was not able to get gsts to parse the region from `~/.aws/config` even though the profile is set correctly, and that forced me to have to explicitly specify `--aws-region` to the `gsts` command in `~/.aws/config`. With this change, it's now able to correctly parse the region from the AWS config.